### PR TITLE
added get_owner() function

### DIFF
--- a/src/thanks/assembly/index.ts
+++ b/src/thanks/assembly/index.ts
@@ -22,6 +22,10 @@ export class Contract {
     }
   }
 
+  get_owner(): AccountId {
+    return this.owner
+  }
+
   @mutateState()
   say(message: string, anonymous: bool = false): bool {
     // guard against too much money being deposited to this account in beta


### PR DESCRIPTION
This function is needed for NCD.L2.sample--thanks
if get_owner == wallet.getAccountId(), then we can owner functions 
By owner functions I mean functions with '  this.assert_owner() ' 
In my opinion is easier to maintain with 1 view function and to call to 2 change functions and then by getting error make decision about which components do we need to show to user in UI